### PR TITLE
Remove explicit specification for runc path.

### DIFF
--- a/install-kata-containerd.sh
+++ b/install-kata-containerd.sh
@@ -17,7 +17,7 @@ cat << EOT | tee /etc/containerd/config.toml
       snapshotter = "overlayfs"
       [plugins.cri.containerd.default_runtime]
         runtime_type = "io.containerd.runtime.v1.linux"
-        runtime_engine = "/usr/bin/runc"
+        runtime_engine = ""
         runtime_root = ""
       [plugins.cri.containerd.untrusted_workload_runtime]
         runtime_type = "io.containerd.runtime.v1.linux"


### PR DESCRIPTION
If containerd has been installed from the v1.1 release tarball it places runc in /usr/local/sbin rather than /usr/bin. Not explicitly specifying the path allows containerd to support a variety of runc locations.