### PR TITLE
Move scripts into configmap and mount

### DIFF
--- a/kata-deploy.yaml
+++ b/kata-deploy.yaml
@@ -1,5 +1,112 @@
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kata-scripts
+  namespace: kube-system
+data:
+  install-kata-containerd.sh: |
+    #!/bin/sh
+
+    ## move Kata artifacts to /opt
+    echo "copying kata artifacts from /tmp to /opt"
+    cp -R /tmp/kata/* /opt/kata/
+    chmod +x /opt/kata/bin/*
+
+    cp /opt/kata/configuration.toml /usr/share/defaults/kata-containers/configuration.toml
+
+    ## Configure containerd to use Kata:
+    echo "create containerd configuration for Kata"
+    mkdir -p /etc/containerd/
+
+    cat << EOT | tee /etc/containerd/config.toml
+    [plugins]
+        [plugins.cri.containerd]
+          snapshotter = "overlayfs"
+          [plugins.cri.containerd.default_runtime]
+            runtime_type = "io.containerd.runtime.v1.linux"
+            runtime_engine = ""
+            runtime_root = ""
+          [plugins.cri.containerd.untrusted_workload_runtime]
+            runtime_type = "io.containerd.runtime.v1.linux"
+            runtime_engine = "/opt/kata/bin/kata-runtime"
+            runtime_root = ""
+    EOT
+
+
+    echo "Reload systemd services"
+    systemctl daemon-reload
+    systemctl restart containerd
+
+  install-kata-crio.sh: |
+    #!/bin/sh
+
+    ## move Kata artifacts to /opt
+    echo "copying kata artifacts from /tmp to /opt"
+    cp -R /tmp/kata/* /opt/kata/
+
+    chmod +x /opt/kata/bin/*
+
+    cp /opt/kata/configuration.toml /usr/share/defaults/kata-containers/configuration.toml
+
+    crio_config_file="/etc/crio/crio.conf"
+
+    cp $crio_config_file $crio_config_file.bak
+
+    cp /etc/crio/crio.conf /etc/crio/crio.conf.bak
+
+    ## Configure CRIO to use Kata:
+
+    ### Configure CRIO to use Kata:
+
+    ## Uncomment next line if you'd like to have default trust level for the cluster be "untrusted":
+    # sed -i 's/default_workload_trust = "trusted"/default_workload_trust = "untrusted"/' "$crio_config_file"
+
+    echo "Set Kata containers as default runtime in CRI-O for untrusted workloads"
+    sed -i 's/runtime_untrusted_workload = ""/runtime_untrusted_workload = "\/opt\/kata\/bin\/kata-runtime"/' /etc/crio/crio.conf
+    echo "Reload systemd services"
+
+    systemctl daemon-reload
+    systemctl restart crio
+
+    ### Restart CRIO:
+
+  remove-kata-containerd.sh: |
+    #!/bin/sh
+
+    ## move Kata artifacts to /opt
+    echo "copying kata artifacts from /tmp to /opt"
+    cp -R /tmp/kata/* /opt/kata/
+    chmod +x /opt/kata/bin/*
+    rm -rf /opt/kata
+    rm -rf /usr/share/defaults/kata-containers
+    rm -f /etc/containerd/config.toml
+
+    echo "Reload systemd services"
+    systemctl daemon-reload
+    systemctl restart containerd
+
+  remove-kata-crio.sh: |
+    #!/bin/sh
+
+    ## move Kata artifacts to /opt
+    echo "copying kata artifacts from /tmp to /opt"
+    rm -rf /opt/kata/
+    rm -rf /usr/sahre/defaults/kata-containers
+
+    crio_config_file="/etc/crio/crio.conf"
+
+    cp $crio_config_file $crio_config_file.bak
+
+    mv /etc/crio/crio.conf.bak /etc/crio/crio.conf
+
+    echo "Reload systemd services"
+
+    systemctl daemon-reload
+    systemctl restart crio
+
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kata-label-node
@@ -94,10 +201,10 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: [ "sh", "-c", "/remove-kata-crio.sh && kubectl label node $NODE_NAME kata-runtime-"]
+              command: [ "sh", "-c", "/opt/kata/scripts/remove-kata-crio.sh && kubectl label node $NODE_NAME kata-runtime-"]
         command: [ "sh", "-c" ]
         args:
-        - /install-kata-crio.sh && kubectl label node $NODE_NAME kata-runtime=true;
+        - /opt/kata/scripts/install-kata-crio.sh && kubectl label node $NODE_NAME kata-runtime=true;
           kubectl get node $NODE_NAME --show-labels;
           while true;
           do sleep 36000; done;
@@ -115,6 +222,8 @@ spec:
           mountPath: /usr/share/defaults/kata-containers/
         - name: kata-artifacts
           mountPath: /opt/kata/
+        - name: kata-scripts
+          mountPath: /opt/kata/scripts
         - name: dbus
           mountPath: /var/run/dbus
         - name: systemd
@@ -131,6 +240,10 @@ spec:
           hostPath:
             path: /opt/kata/
             type: DirectoryOrCreate
+        - name: kata-scripts
+          configMap:
+            name: kata-scripts
+            defaultMode: 484
         - name: dbus
           hostPath:
             path: /var/run/dbus
@@ -166,10 +279,10 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["sh", "-c", "/remove-kata-containerd.sh && kubectl label node $NODE_NAME kata-runtime-"]
+              command: ["sh", "-c", "/opt/kata/scripts/remove-kata-containerd.sh && kubectl label node $NODE_NAME kata-runtime-"]
         command: [ "sh", "-c" ]
         args:
-        - /install-kata-containerd.sh && kubectl label node $NODE_NAME kata-runtime=true;
+        - /opt/kata/scripts/install-kata-containerd.sh && kubectl label node $NODE_NAME kata-runtime=true;
           kubectl get node $NODE_NAME --show-labels;
           while true;
           do sleep 30; done;
@@ -187,6 +300,8 @@ spec:
           mountPath: /usr/share/defaults/kata-containers/
         - name: kata-artifacts
           mountPath: /opt/kata/
+        - name: kata-scripts
+          mountPath: /opt/kata/scripts
         - name: dbus
           mountPath: /var/run/dbus
         - name: systemd
@@ -204,6 +319,10 @@ spec:
           hostPath:
             path: /opt/kata/
             type: DirectoryOrCreate
+        - name: kata-scripts
+          configMap:
+            name: kata-scripts
+            defaultMode: 484
         - name: dbus
           hostPath:
             path: /var/run/dbus


### PR DESCRIPTION
This would avoid rebuilding docker images to iterate on the deploy. Tested with containerd only.